### PR TITLE
修复GetInfo项目中get_device_info函数的内存分配错误

### DIFF
--- a/GetInfo/main.cpp
+++ b/GetInfo/main.cpp
@@ -10,7 +10,7 @@ void get_device_info(cl_device_id device, cl_device_info param_name, std::string
     T* info;
     size_t info_size = 0;
     clGetDeviceInfo(device, param_name, 0, NULL, &info_size);
-    info = (T*)malloc(info_size / sizeof(T));
+    info = (T*)malloc(info_size);
     std::cout << name <<" info num " << info_size / sizeof(T) << ":";
     clGetDeviceInfo(device, param_name, info_size, info, &info_size);
     


### PR DESCRIPTION
用GDB调试的时候发现内存分配错误：
cl_device_max_work_item_sizes info num 3:256,256,256,warning: HEAP[test.exe]:
warning: Heap block at 000001A7AA312010 modified at 000001A7AA312023 past requested size of 3

Thread 1 received signal SIGTRAP, Trace/breakpoint trap.
0x00007ff8ded8a773 in ntdll!RtlRegisterSecureMemoryCacheCallback () from C:\Windows\SYSTEM32\ntdll.dll

是因为malloc分配的内存大小错了。